### PR TITLE
Add space backdrop with stars

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       margin: 0;
       overflow: hidden;
       font-family: 'Indie Flower', cursive;
-      background-color: #f5f5f5;
+      background-color: #000;
     }
 
     #info {
@@ -23,7 +23,7 @@
       top: 10px;
       width: 100%;
       text-align: center;
-      color: #555;
+      color: #fff;
       pointer-events: none;
       font-size: 18px;
     }
@@ -32,35 +32,37 @@
       position: absolute;
       bottom: 20px;
       left: 20px;
-      background: rgba(255, 255, 255, 0.8);
+      background: rgba(0, 0, 0, 0.6);
       padding: 10px;
       border-radius: 10px;
-      box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+      box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
       font-family: 'Indie Flower', cursive;
+      color: #fff;
     }
 
     .planet-label {
       position: absolute;
-      color: #333;
-      background: rgba(255, 255, 255, 0.7);
+      color: #fff;
+      background: rgba(0, 0, 0, 0.7);
       padding: 3px 8px;
       border-radius: 12px;
       pointer-events: none;
       font-family: 'Indie Flower', cursive;
       font-size: 14px;
-      box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+      box-shadow: 0 0 5px rgba(255, 255, 255, 0.1);
     }
 
     .hand-drawn {
       border: 2px dashed #999;
-      box-shadow: 0 0 0 4px #fff, 0 0 10px rgba(0, 0, 0, 0.2);
-      background-color: rgba(255, 255, 255, 0.5);
+      box-shadow: 0 0 0 4px #fff, 0 0 10px rgba(255, 255, 255, 0.2);
+      background-color: rgba(255, 255, 255, 0.3);
     }
 
     button {
       font-family: 'Indie Flower', cursive;
-      background-color: rgba(255, 255, 255, 0.7);
-      border: 1px solid #aaa;
+      background-color: rgba(255, 255, 255, 0.2);
+      border: 1px solid #888;
+      color: #fff;
       border-radius: 8px;
       padding: 5px 10px;
       margin: 5px;
@@ -70,7 +72,7 @@
 
     button:hover {
       transform: translateY(-2px);
-      background-color: rgba(255, 255, 255, 0.9);
+      background-color: rgba(255, 255, 255, 0.4);
     }
 
     button:active {
@@ -93,7 +95,7 @@
   <script>
     // Initialize Three.js scene
     const scene = new THREE.Scene();
-    scene.background = new THREE.Color(0xf5f5f5);
+    scene.background = new THREE.Color(0x000000);
 
     // Camera setup
     const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
@@ -119,11 +121,27 @@
     directionalLight.position.set(10, 20, 10);
     scene.add(directionalLight);
 
+    // Star field
+    const starGeometry = new THREE.BufferGeometry();
+    const starCount = 1000;
+    const starVertices = [];
+    for (let i = 0; i < starCount; i++) {
+      const r = 200;
+      const x = (Math.random() - 0.5) * r * 2;
+      const y = (Math.random() - 0.5) * r * 2;
+      const z = (Math.random() - 0.5) * r * 2;
+      starVertices.push(x, y, z);
+    }
+    starGeometry.setAttribute('position', new THREE.Float32BufferAttribute(starVertices, 3));
+    const starMaterial = new THREE.PointsMaterial({ color: 0xffffff, size: 0.7 });
+    const starField = new THREE.Points(starGeometry, starMaterial);
+    scene.add(starField);
+
     // Hand-drawn style materials
     const sunMaterial = createHandDrawnMaterial(0xffeb3b);
     const planetMaterial = (color) => createHandDrawnMaterial(color);
     const orbitMaterial = new THREE.LineBasicMaterial({
-      color: 0xcccccc,
+      color: 0x555555,
       transparent: true,
       opacity: 0.5
     });
@@ -322,7 +340,7 @@
           }
           moonOrbitGeometry.setFromPoints(moonOrbitPoints);
           const moonOrbitLine = new THREE.Line(moonOrbitGeometry, new THREE.LineBasicMaterial({
-            color: 0xaaaaaa,
+            color: 0x555555,
             transparent: true,
             opacity: 0.3
           }));


### PR DESCRIPTION
## Summary
- switch scene and page background to black
- adjust UI colors for dark mode
- add a procedural star field around the solar system
- tweak orbit line colors to stand out on a dark background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686eabfbab54832bbd2bde59e9f4ebde