### PR TITLE
Improve star field behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,14 +126,22 @@
     const starCount = 1000;
     const starVertices = [];
     for (let i = 0; i < starCount; i++) {
-      const r = 200;
-      const x = (Math.random() - 0.5) * r * 2;
-      const y = (Math.random() - 0.5) * r * 2;
-      const z = (Math.random() - 0.5) * r * 2;
+      const baseRadius = 1000;
+      const offset = Math.random() * 100; // slight variation so stars aren't on a perfect sphere
+      const r = baseRadius + offset;
+      const theta = Math.acos(2 * Math.random() - 1);
+      const phi = 2 * Math.PI * Math.random();
+      const x = r * Math.sin(theta) * Math.cos(phi);
+      const y = r * Math.sin(theta) * Math.sin(phi);
+      const z = r * Math.cos(theta);
       starVertices.push(x, y, z);
     }
     starGeometry.setAttribute('position', new THREE.Float32BufferAttribute(starVertices, 3));
-    const starMaterial = new THREE.PointsMaterial({ color: 0xffffff, size: 0.7 });
+    const starMaterial = new THREE.PointsMaterial({
+      color: 0xffffff,
+      size: 3,
+      sizeAttenuation: false
+    });
     const starField = new THREE.Points(starGeometry, starMaterial);
     scene.add(starField);
 


### PR DESCRIPTION
## Summary
- randomize a far-away shell for stars
- keep stars 3px big regardless of zoom so they appear distant

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686eb36c0c40832b85317f6bc743e80b