### PR TITLE
Add Earth texture

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,6 +148,9 @@
     // Hand-drawn style materials
     const sunMaterial = createHandDrawnMaterial(0xffeb3b);
     const planetMaterial = (color) => createHandDrawnMaterial(color);
+
+    // Texture for Earth skin
+    const earthTexture = new THREE.TextureLoader().load('IMG_3077.jpeg');
     const orbitMaterial = new THREE.LineBasicMaterial({
       color: 0xa5a5a5,
       transparent: true,
@@ -243,7 +246,12 @@
     // Create planets
     planetsData.forEach(data => {
       const geometry = new THREE.SphereGeometry(data.radius, 32, 32);
-      const material = planetMaterial(data.color);
+      let material;
+      if (data.name === "Earth") {
+        material = new THREE.MeshStandardMaterial({ map: earthTexture });
+      } else {
+        material = planetMaterial(data.color);
+      }
       const planet = new THREE.Mesh(geometry, material);
       planet.castShadow = planet.receiveShadow = true;
 


### PR DESCRIPTION
## Summary
- add a texture loader for Earth
- use the skin texture for Earth's material so it rotates with the planet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ebc20924c832bbdf19b49c2339e0c