### PR TITLE
Fix satellite size and visibility scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -669,8 +669,8 @@
     function createSatellite() {
       const satelliteGroup = new THREE.Group();
 
-      // Main body (small box)
-      const bodyGeometry = new THREE.BoxGeometry(0.04, 0.04, 0.06);
+      // Main body (small box) - reduced size 10x
+      const bodyGeometry = new THREE.BoxGeometry(0.004, 0.004, 0.006);
       const bodyMaterial = new THREE.MeshStandardMaterial({
         color: 0xcccccc,
         metalness: 0.8,
@@ -681,8 +681,8 @@
       const body = new THREE.Mesh(bodyGeometry, bodyMaterial);
       satelliteGroup.add(body);
 
-      // Solar panels (two wings)
-      const panelGeometry = new THREE.BoxGeometry(0.12, 0.08, 0.002);
+      // Solar panels (two wings) - reduced size 10x
+      const panelGeometry = new THREE.BoxGeometry(0.012, 0.008, 0.0002);
       const panelMaterial = new THREE.MeshStandardMaterial({
         color: 0x1a3a5a,
         metalness: 0.5,
@@ -693,23 +693,23 @@
 
       // Left panel
       const leftPanel = new THREE.Mesh(panelGeometry, panelMaterial);
-      leftPanel.position.set(-0.08, 0, 0);
+      leftPanel.position.set(-0.008, 0, 0);
       satelliteGroup.add(leftPanel);
 
       // Right panel
       const rightPanel = new THREE.Mesh(panelGeometry, panelMaterial);
-      rightPanel.position.set(0.08, 0, 0);
+      rightPanel.position.set(0.008, 0, 0);
       satelliteGroup.add(rightPanel);
 
-      // Small antenna
-      const antennaGeometry = new THREE.CylinderGeometry(0.002, 0.002, 0.03, 8);
+      // Small antenna - reduced size 10x
+      const antennaGeometry = new THREE.CylinderGeometry(0.0002, 0.0002, 0.003, 8);
       const antennaMaterial = new THREE.MeshStandardMaterial({
         color: 0xffffff,
         metalness: 0.9,
         roughness: 0.1
       });
       const antenna = new THREE.Mesh(antennaGeometry, antennaMaterial);
-      antenna.position.set(0, 0.035, 0);
+      antenna.position.set(0, 0.0035, 0);
       satelliteGroup.add(antenna);
 
       return satelliteGroup;
@@ -778,21 +778,26 @@
     function updateSatelliteVisibility() {
       starlinkSatellites.forEach(sat => {
         if (satelliteVisibility === 'highly') {
-          sat.mesh.scale.set(3, 3, 3); // Make them bigger for high visibility
-          sat.mesh.children.forEach(child => {
-            if (child.material) {
-              child.material.emissiveIntensity = child.material.emissiveIntensity * 2;
-            }
-          });
-        } else {
-          sat.mesh.scale.set(1, 1, 1); // Normal size
+          sat.mesh.scale.set(1, 1, 1); // Normal size for high visibility
           sat.mesh.children.forEach(child => {
             if (child.material && child.material.emissive) {
-              // Reset to original emissive intensity
+              // Standard emissive intensity
               if (child === sat.mesh.children[0]) { // body
                 child.material.emissiveIntensity = 0.3;
               } else if (child.geometry instanceof THREE.BoxGeometry) { // panels
                 child.material.emissiveIntensity = 0.2;
+              }
+            }
+          });
+        } else {
+          sat.mesh.scale.set(0.3, 0.3, 0.3); // Much smaller for slight visibility
+          sat.mesh.children.forEach(child => {
+            if (child.material && child.material.emissive) {
+              // Reduced emissive intensity
+              if (child === sat.mesh.children[0]) { // body
+                child.material.emissiveIntensity = 0.15;
+              } else if (child.geometry instanceof THREE.BoxGeometry) { // panels
+                child.material.emissiveIntensity = 0.1;
               }
             }
           });


### PR DESCRIPTION
- Reduced base satellite dimensions by 10x (body, panels, antenna)
- Changed "highly visible" mode from 3x to 1x scale
- Changed "slightly visible" mode from 1x to 0.3x scale with reduced emissive intensity
- Satellites now properly scaled so Earth is visible and not overwhelmed